### PR TITLE
fix doc errors

### DIFF
--- a/docs/reference/trees.rst
+++ b/docs/reference/trees.rst
@@ -77,8 +77,6 @@ Compartment Tree
    CompartmentTree.compute_gmc
    CompartmentTree.compute_g_channels
    CompartmentTree.compute_g_single_channel
-   CompartmentTree.compute_concMechGamma
-   CompartmentTree.compute_concMechTau
    CompartmentTree.compute_c
    CompartmentTree.reset_fit_data
    CompartmentTree.run_fit
@@ -130,10 +128,19 @@ Simulate reduced compartmental models
 .. autosummary::
    :toctree: generated/
 
-.. autofunction:: neat.simulations.neuron.neuronmodel.createReducedNeuronModel
+    NeuronCompartmentTree.add_shunt
+    NeuronCompartmentTree.add_double_exp_current
+    NeuronCompartmentTree.add_exp_synapse
+    NeuronCompartmentTree.add_double_exp_synapse
+    NeuronCompartmentTree.add_nmda_synapse
+    NeuronCompartmentTree.add_double_exp_nmda_synapse
+    NeuronCompartmentTree.add_i_clamp
+    NeuronCompartmentTree.add_sin_clamp
+    NeuronCompartmentTree.add_ou_clamp
+    NeuronCompartmentTree.add_ou_conductance
+    NeuronCompartmentTree.add_ou_reversal
+    NeuronCompartmentTree.add_v_clamp
 
-.. autosummary::
-   :toctree: generated/
 
 
 *******************
@@ -181,8 +188,10 @@ Relating to the computational tree.
 .. autosummary::
    :toctree: generated/
 
-   MorphTree.setTreetype
-   MorphTree.treetype
+   MorphTree.set_default_tree
+   MorphTree.as_original_tree
+   MorphTree.check_computational_tree_active
+   MorphTree.as_computational_tree
    MorphTree.read_swc_tree_from_file
    MorphTree.set_comp_tree
    MorphTree._evaluate_comp_criteria
@@ -393,7 +402,6 @@ Individual fit functions.
    CompartmentFitter.create_tree_sov
    CompartmentFitter.fit_leak_only
    CompartmentFitter.fit_passive
-   CompartmentFitter.eval_channel
    CompartmentFitter.fit_channels
    CompartmentFitter.fit_concentration
    CompartmentFitter.fit_capacitance
@@ -411,7 +419,7 @@ Defining ion channels
    IonChannel.set_default_params
    IonChannel.compute_p_open
    IonChannel.compute_derivatives
-   IonChannel.compute_derivativesConc
+   IonChannel.compute_derivatives_conc
    IonChannel.compute_varinf
    IonChannel.compute_tauinf
    IonChannel.compute_linear

--- a/neat/channels/ionchannels.py
+++ b/neat/channels/ionchannels.py
@@ -372,7 +372,7 @@ class IonChannel(object):
 
     def set_default_params(self, **kwargs):
         """
-        **kwargs
+        kwargs
             Default values for temperature (`temp`), reversal (`e`)
         """
         self.default_params.update(kwargs)
@@ -477,7 +477,7 @@ class IonChannel(object):
         ----------
         v: float or `np.ndarray` of float
             The voltage at which to evaluate the open probability
-        **kwargs: float or `np.ndarray`
+        kwargs: float or `np.ndarray`
             Optional values for the state variables and concentrations.
 
         Returns
@@ -499,7 +499,7 @@ class IonChannel(object):
         ----------
         v: float or `np.ndarray`
             The voltage at which to evaluate the open probability
-        **kwargs: float or `np.ndarray`
+        kwargs: float or `np.ndarray`
             Optional values for the state variables and concentrations.
 
         Returns
@@ -518,7 +518,7 @@ class IonChannel(object):
         ----------
         v: float or `np.ndarray`
             The voltage at which to evaluate the open probability
-        **kwargs: float or `np.ndarray`
+        kwargs: float or `np.ndarray`
             Optional values for the state variables and concentrations.
 
         Returns
@@ -578,7 +578,7 @@ class IonChannel(object):
         v_resp: `np.ndarray` (``dtype=complex``, ``ndim=1``, ``shape=(s,k)``)
             Linearized voltage responses in the frequency domain, evaluated at
             ``s`` frequencies and ``k`` locations
-        **kwargs: float or `np.ndarray`
+        kwargs: float or `np.ndarray`
             Optional values for the state variables and concentrations.
 
         Returns
@@ -615,7 +615,7 @@ class IonChannel(object):
             The voltage ``[mV]`` at which to evaluate the open probability
         freqs float, complex, or `np.ndarray` of float or complex:
             The frequencies ``[Hz]`` at which to evaluate the linearized contribution
-        **kwargs: float or `np.ndarray`
+        kwargs: float or `np.ndarray`
             Optional values for the state variables and concentrations.
 
         Returns
@@ -651,7 +651,7 @@ class IonChannel(object):
             The frequencies ``[Hz]`` at which to evaluate the linearized contribution
         ion: str
             The ion name for which to compute the linearized contribution
-        **kwargs: float or `np.ndarray`
+        kwargs: float or `np.ndarray`
             Optional values for the state variables and concentrations.
 
         Returns
@@ -697,7 +697,7 @@ class IonChannel(object):
         e: float or `None`
             The reversal potential of the channel. Defaults to the value stored
             in `self.default_params['e']` if not provided.
-        **kwargs: float or `np.ndarray`
+        kwargs: float or `np.ndarray`
             Optional values for the state variables and concentrations.
 
         Returns
@@ -725,7 +725,7 @@ class IonChannel(object):
         e: float or `None`
             The reversal potential of the channel. Defaults to the value stored
             in `self.default_params['e']` if not provided.
-        **kwargs: float or `np.ndarray`
+        kwargs: float or `np.ndarray`
             Optional values for the state variables and concentrations.
 
         Returns

--- a/neat/channels/ionchannels.py
+++ b/neat/channels/ionchannels.py
@@ -510,7 +510,7 @@ class IonChannel(object):
         args = self._args_as_list(v, **kwargs)
         return self.dp_dx(*args), self.df_dv(*args), self.df_dx(*args)
 
-    def compute_derivativesConc(self, v, **kwargs):
+    def compute_derivatives_conc(self, v, **kwargs):
         """
         Compute the derivatives of the state functions to the concentrations
 
@@ -661,7 +661,7 @@ class IonChannel(object):
             the dimensions of `v`.
         """
         dp_dx, df_dv, df_dx = self.compute_derivatives(v, **kwargs)
-        df_dc = self.compute_derivativesConc(v, **kwargs)
+        df_dc = self.compute_derivatives_conc(v, **kwargs)
 
         # determine the output shape according to numpy broadcasting rules
         args_aux = [freqs] + self._args_as_list(v, **kwargs)

--- a/neat/modelreduction/cachetrees.py
+++ b/neat/modelreduction/cachetrees.py
@@ -227,7 +227,7 @@ class EquilibriumTree(CachedTree):
             if `list` of locations, specifies the locations for which the
             equilibrium state evaluated, if ``string``, specifies the
             name under which a set of locations is stored
-        ions: `iterable` of `str
+        ions: `iterable` of `str`
             the names of the ions for which the concentration needs to be measured
         method: Literal: 'interp' or 'sim'
             whether to use interpolation or simulation. Defaults to simulation if
@@ -331,13 +331,13 @@ class EquilibriumTree(CachedTree):
 
         Parameters
         ----------
-        ions: `list` of `str
+        ions: list of str
             the names of the ions for which the concentration needs to be measured
         t_max: float
             duration of the simulation
         dt: float
             time-step of the simulation
-        factor_lambda: `float`
+        factor_lambda: float
             multiplies the number of compartments suggested by the lambda-rule
         """
         self.maybe_execute_funcs(

--- a/neat/simulations/neuron/neuronmodel.py
+++ b/neat/simulations/neuron/neuronmodel.py
@@ -1179,7 +1179,7 @@ class NeuronCompartmentTree(NeuronSimTree):
 
         Parameters
         ----------
-        loc: dict, tuple or :class:`neat.MorphLoc`
+        loc_idx: int, dict, tuple or :class:`neat.MorphLoc`
             The location of the shunt.
         g: float
             The conductance of the shunt (uS)
@@ -1195,7 +1195,7 @@ class NeuronCompartmentTree(NeuronSimTree):
 
         Parameters
         ----------
-        loc: dict, tuple or :class:`neat.MorphLoc`
+        loc_idx: int, dict, tuple or :class:`neat.MorphLoc`
             The location of the current.
         tau1: float
             Rise time of the current waveform (ms)
@@ -1211,7 +1211,7 @@ class NeuronCompartmentTree(NeuronSimTree):
 
         Parameters
         ----------
-        loc: dict, tuple or :class:`neat.MorphLoc`
+        loc_idx: int, dict, tuple or :class:`neat.MorphLoc`
             The location of the current.
         tau: float
             Decay time of the conductance window (ms)
@@ -1227,7 +1227,7 @@ class NeuronCompartmentTree(NeuronSimTree):
 
         Parameters
         ----------
-        loc: dict, tuple or :class:`neat.MorphLoc`
+        loc_idx: int, dict, tuple or :class:`neat.MorphLoc`
             The location of the current.
         tau1: float
             Rise time of the conductance window (ms)
@@ -1246,7 +1246,7 @@ class NeuronCompartmentTree(NeuronSimTree):
 
         Parameters
         ----------
-        loc: dict, tuple or :class:`neat.MorphLoc`
+        loc_idx: int, dict, tuple or :class:`neat.MorphLoc`
             The location of the current.
         tau: float
             Decay time of the AMPA conductance window (ms)
@@ -1269,7 +1269,7 @@ class NeuronCompartmentTree(NeuronSimTree):
 
         Parameters
         ----------
-        loc: dict, tuple or :class:`neat.MorphLoc`
+        loc_idx: int, dict, tuple or :class:`neat.MorphLoc`
             The location of the current.
         tau1: float
             Rise time of the AMPA conductance window (ms)
@@ -1295,7 +1295,7 @@ class NeuronCompartmentTree(NeuronSimTree):
 
         Parameters
         ----------
-        loc: dict, tuple or :class:`neat.MorphLoc`
+        loc_idx: int, dict, tuple or :class:`neat.MorphLoc`
             The location of the current.
         amp: float
             The amplitude of the current (nA)
@@ -1313,7 +1313,7 @@ class NeuronCompartmentTree(NeuronSimTree):
 
         Parameters
         ----------
-        loc: dict, tuple or :class:`neat.MorphLoc`
+        loc_idx: int, dict, tuple or :class:`neat.MorphLoc`
             The location of the current.
         amp: float
             The amplitude of the current (nA)
@@ -1337,7 +1337,7 @@ class NeuronCompartmentTree(NeuronSimTree):
 
         Parameters
         ----------
-        loc: dict, tuple or :class:`neat.MorphLoc`
+        loc_idx: int, dict, tuple or :class:`neat.MorphLoc`
             The location of the current.
         tau: float
             Time-scale of the OU process (ms)
@@ -1361,7 +1361,7 @@ class NeuronCompartmentTree(NeuronSimTree):
 
         Parameters
         ----------
-        loc: dict, tuple or :class:`neat.MorphLoc`
+        loc_idx: int, dict, tuple or :class:`neat.MorphLoc`
             The location of the conductance.
         tau: float
             Time-scale of the OU process (ms)
@@ -1391,7 +1391,7 @@ class NeuronCompartmentTree(NeuronSimTree):
 
         Parameters
         ----------
-        loc: dict, tuple or :class:`neat.MorphLoc`
+        loc_idx: int, dict, tuple or :class:`neat.MorphLoc`
             The location of the conductance.
         e_c: float
             The clamping voltage (mV)

--- a/neat/tools/kernelextraction.py
+++ b/neat/tools/kernelextraction.py
@@ -51,7 +51,7 @@ class ExpFitter(Fitter):
         Construct a sum of exponentials fit to a given time-sequence y by
         using prony's method
 
-        input:
+        Parameters:
             [deg]: int, number of exponentials
             [x]: numpy array, sequence of regularly spaced points at which y is evaluated
             [y]: numpy array, sequence
@@ -152,7 +152,7 @@ class ExpFitter(Fitter):
         Reduces the number of exponential terms in a series, till a given tolerance
         is reached
 
-        input:
+        Parameters:
             [a]: numpy array of exponential timescales
             [c]: numpy array of exponential magnitudes
             [x]: numpy array of x-values at which the function is evaluated
@@ -800,7 +800,7 @@ class fExpFitter(Fitter):
         """
         Fits a function in fourrierspace by a series of fourrier transformed exponentials.
 
-        input:
+        Parameters:
             -args
             [s]: numpy array of frequencies (imaginary) at which value function is evaluated
             [y]: numpy array of complex function values
@@ -926,7 +926,7 @@ class fExpFitter(Fitter):
         """
         Fit multiple data-arrays in Fourrier-domain simultaneously with a shared set of nodes
 
-        input:
+        Parameters:
             [s]: numpy array of complex number, frequencies of data
             [ys]: numpy ndarray of complex numbers, rows are different data-arrays
             [deg]: int, the starting number of nodes
@@ -1131,7 +1131,7 @@ class expExtractor(object):
         """
         Fit a partial fraction decomposition to the obtained kernel in the frequency domain
 
-        input:
+        Parameters:
             N (int): the number of exponenstials to use
             recalc (bool): whether to force a refit if a fit with the given N already exists
             atol (float): the tolerance, if the RMSE of the fit is higher
@@ -1245,7 +1245,8 @@ class kernelExtractor(expExtractor):
     This class computes the rescale kernel between the
     synapse in the dendrite and the synapse in the soma.
 
-    input:
+    Parameters
+    ----------
         vdend (numpy 1d array): the somatic voltage recording
             with the synapse in the dendrites
         vsoma (numpy 1d array): the somatic voltage recording

--- a/neat/trees/morphtree.py
+++ b/neat/trees/morphtree.py
@@ -633,6 +633,19 @@ class MorphTree(STree):
             )
 
     def set_default_tree(self, default: Literal['original', 'computational'] = 'original'):
+        """
+        Set the tree type that is by default active
+
+        Parameters
+        ----------
+        default : Literal[&#39;original&#39;, &#39;computational&#39;], optional
+            the treetype that is by default active
+
+        Raises
+        ------
+        ValueError
+            if `default` argument is not 'original' or 'computational'
+        """
         if default == 'original':
             self.root = self._original_root
         elif default == 'computational':
@@ -644,6 +657,14 @@ class MorphTree(STree):
     @property
     @contextmanager
     def as_computational_tree(self):
+        """
+        Context manager that ensures the computational tree is active.
+
+        Yields
+        ------
+        self
+            `self` with the computational tree activated
+        """
         self._check_computational_root()
         treetype = 'computational' if self.check_computational_tree_active() else 'original'
         self.root = self._computational_root
@@ -657,6 +678,14 @@ class MorphTree(STree):
     @property
     @contextmanager
     def as_original_tree(self):
+        """
+        Context manager that ensures the original tree is active.
+
+        Yields
+        ------
+        self
+            `self` with the original tree activated
+        """
         treetype = 'computational' if self.check_computational_tree_active() else 'original'
         self.root = self._original_root
         try:

--- a/neat/trees/netree.py
+++ b/neat/trees/netree.py
@@ -371,7 +371,7 @@ class NET(STree):
 
     def get_reduced_tree(self, loc_idxs, indexing='NET eval'):
         """
-        Construct a reduced tree where only the locations index by ``loc_idxs''
+        Construct a reduced tree where only the locations index by ``loc_idxs``
         are retained
 
         Parameters


### PR DESCRIPTION
Removed a few non-existent function from `docs/reference/trees.rst` and added some functions that were not yet there, and fixed some docstrings that were causing warnings. Still a lot of warnings though.